### PR TITLE
Fix KeyError when user has no avatar

### DIFF
--- a/OAuth2Client/AuthorizationHelpers.py
+++ b/OAuth2Client/AuthorizationHelpers.py
@@ -104,7 +104,7 @@ class AuthorizationHelpers:
         return UserProfile(
             user_id = user_data["user_id"],
             username = user_data["username"],
-            profile_image_url = user_data["profile_image_url"]
+            profile_image_url = user_data.get("profile_image_url", "")
         )
 
     @staticmethod


### PR DESCRIPTION
I get a KeyError after I signed in and pressed "Allow". Seems to be caused by me having no avatar. If I apply this change, things seem to work and I get the default avatar.