### PR TITLE
Update preferences

### DIFF
--- a/OAuth2Client/models.py
+++ b/OAuth2Client/models.py
@@ -14,6 +14,7 @@ class OAuth2Settings(BaseModel):
     CLIENT_ID = None  # type: Optional[str]
     CLIENT_SCOPES = None  # type: Optional[str]
     CALLBACK_URL = None  # type: Optional[str]
+    AUTH_DATA_PREFERENCE_KEY = None  # type: Optional[str]
     AUTH_SUCCESS_REDIRECT = "https://ultimaker.com"  # type: str
     AUTH_FAILED_REDIRECT = "https://ultimaker.com"  # type: str
 


### PR DESCRIPTION
* Use `application.getPreferences` instead of `Preferences.getInstance()` to get the Cura preferences (new preferred method in Cura 3.4).
* Extract the preferences storage key to the `Settings` class to a plugin can define their own key.