### PR TITLE
Daemon

### DIFF
--- a/OAuth2Client/AuthorizationService.py
+++ b/OAuth2Client/AuthorizationService.py
@@ -34,7 +34,7 @@ class AuthorizationService:
         self._auth_data = None  # type: Optional[AuthenticationResponse]
         self._user_profile = None  # type: Optional[UserProfile]
         self._cura_preferences = preferences
-        self._server = LocalAuthorizationServer(self._auth_helpers, self._onAuthStateChanged)
+        self._server = LocalAuthorizationServer(self._auth_helpers, self._onAuthStateChanged, daemon=True)
         self._loadAuthData()
 
     def getUserProfile(self) -> Optional["UserProfile"]:


### PR DESCRIPTION
The integration tests were broken with daemon=True, since there the server runs in a subprocess.

We should try to run this in non-daemon mode in the plugins as well.